### PR TITLE
Linking members logos to Sustain Academic Map

### DIFF
--- a/content/about/members/_index.md
+++ b/content/about/members/_index.md
@@ -7,21 +7,21 @@ subtitle: "CURIOSS is a community for university and research institution OSPOs"
     <div class="row justify-content-center">
       {{< company name="Carnegie Mellon University" image="/images/about/logos/cmul.png" url="https://sustainers.github.io/academic-map/universities/carnegie-mellon-university.html"/>}}
       {{< company name="WASHINGTON University" image="/images/about/logos/washington.png" url="https://sustainers.github.io/academic-map/universities/george-washington.html"/>}}
-      {{< company name="Georgia Tech" image="/images/about/logos/georgia.png">}}
+      {{< company name="Georgia Tech" image="/images/about/logos/georgia.png" url="https://sustainers.github.io/academic-map/universities/georgia-institute-of-technology.html"/>}}
       {{< /company >}}
-      {{< company name="JHU Library" image="/images/about/logos/jhu_library.png" >}}
+      {{< company name="JHU Library" image="/images/about/logos/jhu_library.png" url="https://sustainers.github.io/academic-map/universities/johns-hopkins-university.html"/>}}
       {{< /company >}}
-      {{< company name="Lero" image="/images/about/logos/lero_logo.png">}}
+      {{< company name="Lero" image="/images/about/logos/lero_logo.png" url="https://sustainers.github.io/academic-map/universities/lero.html"/>}}
       {{< /company >}}
-      {{< company name="RIT" image="/images/about/logos/rit_logo.png">}}
+      {{< company name="RIT" image="/images/about/logos/rit_logo.png" url="https://sustainers.github.io/academic-map/universities/rit.html"/>}}
       {{< /company >}}
-      {{< company name="Saint Louis University" image="/images/about/logos/slu_logo.png">}}
+      {{< company name="Saint Louis University" image="/images/about/logos/slu_logo.png" url="https://sustainers.github.io/academic-map/universities/saint-louis-university.html"/>}}
       {{< /company >}}
-      {{< company name="Stanford University" image="/images/about/logos/stanford.png">}}
+      {{< company name="Stanford University" image="/images/about/logos/stanford.png" url="https://sustainers.github.io/academic-map/universities/stanford-university.html"/>}}
       {{< /company >}}
-      {{< company name="Syracuse University" image="/images/about/logos/syracuse.png">}}
+      {{< company name="Syracuse University" image="/images/about/logos/syracuse.png" url="https://sustainers.github.io/academic-map/universities/syracuse.html"/>}}
       {{< /company >}}
-      {{< company name="Trinity College" image="/images/about/logos/trinity_college_logo.png">}}
+      {{< company name="Trinity College" image="/images/about/logos/trinity_college_logo.png" url="https://sustainers.github.io/academic-map/universities/trinity-college-dublin.html"/>}}
       {{< /company >}}
       {{< company name="Univerity of California Berkeley">}}
       {{< /company >}}
@@ -33,15 +33,15 @@ subtitle: "CURIOSS is a community for university and research institution OSPOs"
       {{< /company >}}
       {{< company name="University of California Santa Barbara">}}
       {{< /company >}}
-      {{< company name="UCDC" image="/images/about/logos/ucsc.png">}}
+      {{< company name="University of California Santa Cruz" image="/images/about/logos/ucsc.png" url="https://sustainers.github.io/academic-map/universities/university-of-california-santa-cruz.html"/>}}
       {{< /company >}} 
-      {{< company name="University of Texas at Austin" image="/images/about/logos/university_of_texas.png">}}
+      {{< company name="University of Texas at Austin" image="/images/about/logos/university_of_texas.png" url="https://sustainers.github.io/academic-map/universities/ut-austin.html"/>}}
       {{< /company >}}
       {{< company name="SnT-Université du Luxembourg" image="/images/about/logos/snt.png">}}
       {{< /company >}}
-      {{< company name="University of Vermont" image="/images/about/logos/university_of_vermont_logo.png">}}
+      {{< company name="University of Vermont" image="/images/about/logos/university_of_vermont_logo.png" url="https://sustainers.github.io/academic-map/universities/university-of-vermont.html"/>}}
       {{< /company >}}
-      {{< company name="WISCONSIN University" image="/images/about/logos/wisconsin.png">}}
+      {{< company name="University of Wisconsin-Madison" image="/images/about/logos/wisconsin.png" url="https://sustainers.github.io/academic-map/universities/university-of-wisconsin-madison.html"/>}}
       {{< /company >}}
     </div>
   </div>


### PR DESCRIPTION
Linked members logos from the Members Page [to](https://curioss.org/about/members/) the Sustain Academic Map