### PR TITLE
docs: Change wording slightly

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -290,3 +290,8 @@ button.svelte-la9dd4:disabled {
 //     top: 0;
 //     width: 100%;
 // }
+
+
+.lead b, .lead strong {
+    font-weight: bold;
+}

--- a/content/about/join.md
+++ b/content/about/join.md
@@ -27,4 +27,4 @@ type: wide
     </div>
   </div>
 </section>
-    
+

--- a/data/joincurioss.yml
+++ b/data/joincurioss.yml
@@ -7,7 +7,7 @@ services:
   # service item
   - title: "About CURIOSS"
     icon: "ti-comments" # themify icon pack https://themify.me/themify-icons
-    content: "Find out more about CURIOSS, the organizing and membership. [About CURIOSS ->](/about/)"
+    content: "Find out more about CURIOSS, the organizing and membership [here](/about/)."
 
   # service item
   - title: "Members"
@@ -17,4 +17,4 @@ services:
   # service item
   - title: "Contact CURIOSS"
     icon: "ti-email" # themify icon pack https://themify.me/themify-icons
-    content: "We always love hearing from people working in or with academic OSPOs. To contact us please fill in [this form](/about/contact/)."
+    content: "We always love hearing from people working in or with academic OSPOs. Check out [our contact page](/about/contact/)."


### PR DESCRIPTION
There is no contact form linked. I also made the links a bit clearer, I think.
<img width="1060" alt="Screenshot 2024-07-12 at 19 27 38" src="https://github.com/user-attachments/assets/2ca659f0-6c6e-4c0c-8017-2332539682f9">
