### PR TITLE
Re-position Open News buttons on the News page

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -231,7 +231,7 @@ button.svelte-la9dd4:disabled {
 }
 
 .event-card-text {
-    height: 150px;
+    height: 90px;
     overflow: hidden;
 }
 

--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -52,10 +52,12 @@
               {{ end }}
             </ul>
             <p class="card-text event-card-text">{{ .Description }}</p>
+            <div class="d-flex mt-auto flex-md-row flex-sm-column">
             <a href="{{ default .Permalink .Params.redirect }}" {{ with .Params.target }} target="{{ . }}" {{ end }} class="btn btn-primary btn-sm">Open News</a>
             {{ if .Params.youtubeLink }}
             <a href="{{ .Params.youtubeLink }}" target="_blank" class="btn btn-secondary btn-sm">Watch Recording</a>
             {{ end }}
+          </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The issue applied: https://github.com/CURIOSSorg/curioss.org/issues/44

The buttons now as in the screenshot below:
<img width="1198" alt="Screenshot 2024-09-04 at 20 43 11" src="https://github.com/user-attachments/assets/715f51c9-4334-4a15-8bee-7719f62cb7b1">
