### PR TITLE
Security: Disable unsafe HTML rendering in markdown

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -161,7 +161,7 @@ googleAnalytics: ''
 markup:
   goldmark:
     renderer:
-      unsafe: true
+      unsafe: false  # Security: block dangerous HTML tags like <script>, <iframe>
 minify:
   disableHTML: true
 params:


### PR DESCRIPTION
This PR fixes a security vulnerability by changing Hugo's markdown renderer setting from 'unsafe: true' to 'unsafe: false' in config.yaml.

Before: Any markdown content could inject arbitrary HTML, creating XSS vulnerabilities.
After: Hugo blocks dangerous HTML tags like <script>, <iframe>, etc. while still supporting safe markdown formatting.

The site already uses markdown syntax in YAML data files (bold text, links), which will continue to work safely with this change.