### PR TITLE
Upgrade Font Awesome to 6.7.2 and use native Bluesky icon

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,7 +172,7 @@ params:
       - link: plugins/slick/slick.css
       - link: plugins/youmax/youmax.css
       - link: plugins/bootstrap-select/css/bootstrap-select.min.css
-      - link: https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css
+      - link: https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css
     js:
       - link: plugins/jQuery/jquery.min.js
       - link: plugins/bootstrap/bootstrap.min.js
@@ -187,7 +187,7 @@ params:
       icon: "ti-linkedin"
       url: "https://www.linkedin.com/company/curioss/"
     - name: Bluesky
-      icon: "images/bluesky.svg" 
+      icon: "fab fa-bluesky" 
       url: "https://bsky.app/profile/curiossorg.bsky.social"
     - name: Mastodon
       icon: "fab fa-mastodon" 


### PR DESCRIPTION
This PR upgrades Font Awesome from version 6.4.2 to 6.7.2, which includes native support for the Bluesky icon.

## Changes
- ✨ Upgrade Font Awesome from 6.4.2 to 6.7.2
- 🎨 Replace custom Bluesky SVG image with Font Awesome icon (`fab fa-bluesky`)

## Benefits
- **Consistent styling**: The Bluesky icon now matches the visual style of other social media icons
- **Easier maintenance**: No need to manage custom SVG files for social icons
- **Up-to-date library**: Latest Font Awesome version includes security fixes and improvements

The native Font Awesome Bluesky icon ensures better visual consistency across all social media links on the site.