### PR TITLE
Make homepage service cards fully clickable

### DIFF
--- a/assets/scss/templates/_homepage.scss
+++ b/assets/scss/templates/_homepage.scss
@@ -84,6 +84,23 @@
   }
 }
 
+// Clickable card links
+a.text-decoration-none {
+  .card {
+    cursor: pointer;
+    color: inherit;
+    
+    &:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 10px 30px rgba(0,0,0,0.15) !important;
+    }
+  }
+  
+  &:hover {
+    text-decoration: none;
+  }
+}
+
 .bg-image {
   position: absolute;
   left: 0;

--- a/data/joincurioss.yml
+++ b/data/joincurioss.yml
@@ -7,14 +7,17 @@ services:
   # service item
   - title: "About CURIOSS"
     icon: "ti-comments" # themify icon pack https://themify.me/themify-icons
-    content: "Find out more about CURIOSS, the organizing and membership [here](/about/)."
+    content: "Find out more about CURIOSS, the organizing and membership."
+    url: "/about/"
 
   # service item
   - title: "Members"
     icon: "ti-announcement" # themify icon pack https://themify.me/themify-icons
-    content: "Find out about who is part of the CURIOSS Community on our [Members page](/about/members/)."
+    content: "Find out about who is part of the CURIOSS Community."
+    url: "/about/members/"
 
   # service item
   - title: "Contact CURIOSS"
     icon: "ti-email" # themify icon pack https://themify.me/themify-icons
-    content: "We always love hearing from people working in or with academic OSPOs. Check out [our contact page](/about/contact/)."
+    content: "We always love hearing from people working in or with academic OSPOs."
+    url: "/about/contact/"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,17 +31,19 @@
     <div class="row">
       {{ range first 3 .Site.Data.joincurioss.services }}
       <div class="col-lg-4 mb-4 mb-lg-0">
-        <div class="card hover-bg-secondary shadow py-4">
-          <div class="card-body text-center">
-            <div class="position-relative">
-              <i
-                class="icon-lg icon-box bg-gradient-primary rounded-circle {{ .icon }} mb-5 d-inline-block text-white"></i>
-              <i class="icon-lg icon-watermark text-white {{ .icon }}"></i>
+        <a href="{{ .url }}" class="text-decoration-none">
+          <div class="card hover-bg-secondary shadow py-4">
+            <div class="card-body text-center">
+              <div class="position-relative">
+                <i
+                  class="icon-lg icon-box bg-gradient-primary rounded-circle {{ .icon }} mb-5 d-inline-block text-white"></i>
+                <i class="icon-lg icon-watermark text-white {{ .icon }}"></i>
+              </div>
+              <h4 class="mb-4">{{ .title | markdownify }}</h4>
+              <p>{{ .content | markdownify }}</p>
             </div>
-            <h4 class="mb-4">{{ .title | markdownify }}</h4>
-            <p>{{ .content | markdownify }}</p>
           </div>
-        </div>
+        </a>
       </div>
       {{ end }}
     </div>


### PR DESCRIPTION
Improves UX on the homepage by making the entire About, Members, and Contact cards clickable instead of just the embedded link text.

## Changes
- Wrapped each service card in an anchor tag
- Added `url` field to services in `joincurioss.yml` for cleaner data structure
- Removed inline markdown links from content (better separation of data/presentation)
- Added smooth hover animations: cards lift slightly and get enhanced shadow
- Maintains existing color-change hover behavior

## Benefits
- Better mobile UX (larger touch target)
- More intuitive interaction (whole card is obviously clickable)
- Cleaner data structure (URLs separate from content text)
- Polished hover animations improve perceived responsiveness