### PR TITLE
Revert "Security: Disable unsafe HTML rendering in markdown"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -161,7 +161,7 @@ googleAnalytics: ''
 markup:
   goldmark:
     renderer:
-      unsafe: false  # Security: block dangerous HTML tags like <script>, <iframe>
+      unsafe: true
 minify:
   disableHTML: true
 params:


### PR DESCRIPTION
Reverts CURIOSSorg/curioss.org#174

Broke a few pages. 